### PR TITLE
Fix predis require, related to php 7.1.4 bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "spryker/redis",
   "require": {
-    "predis/predis": "~1.0.3"
+    "predis/predis": "^1.1.1"
   },
   "description": "Redis bundle",
   "license": "proprietary",


### PR DESCRIPTION
PHP in last update (7.0.18 / 7.1.4) introduced bug in fsopen().
In predis 1.1.1 this problem not occurs.

@see https://bugs.php.net/bug.php?id=74216